### PR TITLE
feat: drop unused build dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,17 +60,16 @@
         };
 
         nativeBuildInputs = [
-          pkgs.openssl
           pkgs.pkg-config
         ];
 
         buildInputs = [
           pkgs.openssl
-          pkgs.binaryen
         ];
 
         devInputs = [
           rustToolchainTOML
+          pkgs.binaryen
           pkgs.mkdocs
           pkgs.just
         ];


### PR DESCRIPTION
They are used by the plugin build themselves.