### PR TITLE
Update flake for nix-darwin configs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,13 +69,15 @@
           perl
         ];
 
-        buildInputs = [
-          openssl
-          protobuf
-        ] ++ lib.optionals stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
-          DiskArbitration
-          Foundation
-        ]);
+        buildInputs =
+          [
+            openssl
+            protobuf
+          ]
+          ++ lib.optionals stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
+            DiskArbitration
+            Foundation
+          ]);
 
         patchPhase =
           if patchPlugins

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,8 @@
       openssl,
       perl,
       rust-bin,
+      system,
+      pkgs,
       patchPlugins ? true,
     }: let
       rustToolchainTOML = rust-bin.fromRustupToolchainFile (
@@ -70,15 +72,19 @@
         buildInputs = [
           openssl
           protobuf
-        ];
+        ] ++ lib.optionals stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
+          DiskArbitration
+          Foundation
+        ]);
+
         patchPhase =
           if patchPlugins
           then ''
-            cp ${self.outputs.plugins.x86_64-linux.tab-bar}/bin/tab-bar.wasm zellij-utils/assets/plugins/tab-bar.wasm
-            cp ${self.outputs.plugins.x86_64-linux.status-bar}/bin/status-bar.wasm zellij-utils/assets/plugins/status-bar.wasm
-            cp ${self.outputs.plugins.x86_64-linux.strider}/bin/strider.wasm zellij-utils/assets/plugins/strider.wasm
-            cp ${self.outputs.plugins.x86_64-linux.compact-bar}/bin/compact-bar.wasm zellij-utils/assets/plugins/compact-bar.wasm
-            cp ${self.outputs.plugins.x86_64-linux.session-manager}/bin/session-manager.wasm zellij-utils/assets/plugins/session-manager.wasm
+            cp ${self.outputs.plugins.${system}.tab-bar}/bin/tab-bar.wasm zellij-utils/assets/plugins/tab-bar.wasm
+            cp ${self.outputs.plugins.${system}.status-bar}/bin/status-bar.wasm zellij-utils/assets/plugins/status-bar.wasm
+            cp ${self.outputs.plugins.${system}.strider}/bin/strider.wasm zellij-utils/assets/plugins/strider.wasm
+            cp ${self.outputs.plugins.${system}.compact-bar}/bin/compact-bar.wasm zellij-utils/assets/plugins/compact-bar.wasm
+            cp ${self.outputs.plugins.${system}.session-manager}/bin/session-manager.wasm zellij-utils/assets/plugins/session-manager.wasm
           ''
           else ":";
         meta = {
@@ -127,6 +133,7 @@
           rustc = rustWasmToolchainTOML;
           cargo = rustWasmToolchainTOML;
         };
+
         externalPlugins = pkgs.callPackage ./external-plugins.nix rec {
           src = multitask;
           cargoLock = {
@@ -143,10 +150,10 @@
         packages = rec {
           # The default build compiles the plugins from src
           default = zellij;
-          zellij = pkgs.callPackage make-zellij {inherit stdenv;};
+          zellij = pkgs.callPackage make-zellij {inherit stdenv system pkgs;};
           # The upstream build relies on precompiled binary plugins that are included in the upstream src
           zellij-upstream = pkgs.callPackage make-zellij {
-            inherit stdenv;
+            inherit stdenv system pkgs;
             patchPlugins = false;
           };
         };


### PR DESCRIPTION
Hey,

I'm not a nix specialist or anything, but I use this flake for my linux and macos configs, so needed to update it a bit. 

It's a pretty simple change. Macos requires DiskArbitration and Foundation to build zellij ( you can see it in the mainline nixpkg), so add them here if our system is darwin.


Appreciate all the effort you put in to get this working.
