### PR TITLE
plugins: Update the wasm target to `wasm32-wasip1`

### DIFF
--- a/default-plugins.nix
+++ b/default-plugins.nix
@@ -8,6 +8,7 @@
   stdenv,
   binaryen,
   optimize ? true,
+  wasmTarget ? "wasm32-wasip1",
 }:
 let
   makeDefaultPlugin =
@@ -24,21 +25,21 @@ let
         protobuf
       ];
       buildPhase = ''
-        cargo build --package ${name} --release --target=wasm32-wasi
+        cargo build --package ${name} --release --target=${wasmTarget}
         mkdir -p $out/bin;
       '';
       installPhase =
         if optimize then
           ''
             wasm-opt \
-            -Oz target/wasm32-wasi/release/${name}.wasm \
+            -Oz target/${wasmTarget}/release/${name}.wasm \
             -o $out/bin/${name}.wasm \
             --enable-bulk-memory
           ''
         else
           ''
             mv \
-            target/wasm32-wasi/release/${name}.wasm \
+            target/${wasmTarget}/release/${name}.wasm \
             $out/bin/${name}.wasm
           '';
       doCheck = false;

--- a/external-plugins.nix
+++ b/external-plugins.nix
@@ -8,6 +8,7 @@
   stdenv,
   binaryen,
   optimize ? true,
+  wasmTarget ? "wasm32-wasip1",
 }:
 let
   makePlugin =
@@ -24,24 +25,24 @@ let
         protobuf
       ];
       buildPhase = ''
-        cargo build --package ${name} --release --target=wasm32-wasi
+        cargo build --package ${name} --release --target=${wasmTarget}
         mkdir -p $out/bin;
       '';
       installPhase =
         if optimize then
           ''
             wasm-opt \
-            -Oz target/wasm32-wasi/release/${name}.wasm \
+            -Oz target/${wasmTarget}/release/${name}.wasm \
             -o $out/bin/${name}.wasm \
             --enable-bulk-memory
-            substituteInPlace dev.kdl --replace 'file:target/wasm32-wasi/debug/multitask.wasm' "${placeholder "out"}"
+            substituteInPlace dev.kdl --replace 'file:target/${wasmTarget}/debug/multitask.wasm' "${placeholder "out"}"
             mkdir -p $out/share;
             cp  dev.kdl $out/share/multitask.kdl
           ''
         else
           ''
             mv \
-            target/wasm32-wasi/release/${name}.wasm \
+            target/${wasmTarget}/release/${name}.wasm \
             $out/bin/${name}.wasm
           '';
       doCheck = false;

--- a/flake.nix
+++ b/flake.nix
@@ -126,7 +126,7 @@
         rustToolchainTOML = pkgs.rust-bin.fromRustupToolchainFile (src + /rust-toolchain.toml);
         rustWasmToolchainTOML = rustToolchainTOML.override {
           extensions = [ ];
-          targets = [ "wasm32-wasi" ];
+          targets = [ "wasm32-wasip1" ];
         };
 
         devInputs = [


### PR DESCRIPTION
Previously the `wasm32-wasm` target has been used, which is now deprecated to be used in the future.

Related:

https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html